### PR TITLE
use target currency instead of USD when computing market value

### DIFF
--- a/beangrow/reports.py
+++ b/beangrow/reports.py
@@ -193,7 +193,7 @@ def write_returns_html(dirname: str,
         transactions = data.sorted([txn for ad in account_data for txn in ad.transactions])
 
         # Note: This is where the vast majority of the time is spent.
-        plots = plot_flows(dirname, pricer.price_map,
+        plots = plot_flows(dirname, pricer.price_map, target_currency,
                            cash_flows, transactions, returns.total)
         fprint('<img src={} style="width: 100%"/>'.format(plots["flows"]))
         fprint('<img src={} style="width: 100%"/>'.format(plots["cumvalue"]))
@@ -325,6 +325,7 @@ def plot_prices(output_dir: str,
 
 def plot_flows(output_dir: str,
                price_map: prices.PriceMap,
+               target_currency: Currency,
                flows: List[CashFlow],
                transactions: data.Entries,
                returns_rate: float) -> Dict[str, str]:
@@ -384,7 +385,7 @@ def plot_flows(output_dir: str,
         ax.plot(dates_all, gamounts, color='#000', alpha=0.7, linewidth=lw)
 
     # Overlay value of assets over time.
-    value_dates, value_values = returnslib.compute_portfolio_values(price_map, transactions)
+    value_dates, value_values = returnslib.compute_portfolio_values(price_map, target_currency, transactions)
     ax.plot(value_dates, value_values, color='#00F', alpha=0.5, linewidth=lw)
     ax.scatter(value_dates, value_values, color='#00F', alpha=lw, s=2)
 

--- a/beangrow/returns.py
+++ b/beangrow/returns.py
@@ -71,7 +71,7 @@ def compute_irr(dated_flows: List[CashFlow],
                 end_date: Date) -> float:
     """Compute the irregularly spaced IRR."""
 
-    # Array of cash flows, converted to USD.
+    # Array of cash flows, converted to target currency.
     usd_flows = []
     for flow in dated_flows:
         usd_amount = pricer.convert_amount(flow.amount, target_currency, date=flow.date)
@@ -192,6 +192,7 @@ def truncate_and_merge_cash_flows(
 
 
 def compute_portfolio_values(price_map: prices.PriceMap,
+                             target_currency: Currency,
                              transactions: data.Entries) -> Tuple[List[Date], List[float]]:
     """Compute a serie of portfolio values over time."""
 
@@ -226,7 +227,7 @@ def compute_portfolio_values(price_map: prices.PriceMap,
 
         # Convert to market value.
         value_balance = balance.reduce(convert.get_value, price_map, date)
-        cost_balance = value_balance.reduce(convert.convert_position, "USD", price_map)
+        cost_balance = value_balance.reduce(convert.convert_position, target_currency, price_map)
         pos = cost_balance.get_only_position()
         value = pos.units.number if pos else ZERO
 


### PR DESCRIPTION
I noticed that the market value series in the cumulative value chart doesn't match my expected values. Turns out it always got converted to USD.

This PR updates the code to convert the market value to the target currency.