### PR TITLE
Remove Python dependency upper version bound (<=3.12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ beangrow-prices = "beangrow.download_prices:main"
 beangrow-prices-file = "beangrow.download_prices_from_file:main"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<=3.12"
+python = ">=3.10"
 numpy = "^1.26.4"
 pandas = "^2.2.2"
 matplotlib = "^3.9.0"


### PR DESCRIPTION
The constraint is causing issues with the latest Python versions:

```bash
$ python -V
Python 3.12.4

$ uv pip install beangrow
ERROR: Package 'beangrow' requires a different Python: 3.12.4 not in '<=3.12,>=3.10'
```