### PR TITLE
consider ASSET_DIVIDEND transactions when computing return

### DIFF
--- a/beangrow/investments.py
+++ b/beangrow/investments.py
@@ -188,6 +188,12 @@ def produce_cash_flows_general(entry: data.Directive,
             posting.meta["flow"] = cf
             flows.append(cf)
 
+        elif category == Cat.ASSET and has_dividend:
+            cf = CashFlow(entry.date, convert.get_weight(posting), has_dividend,
+                          "dividend", account)
+            posting.meta["flow"] = cf
+            flows.append(cf)
+
     return flows
 
 


### PR DESCRIPTION
When computing the returns of an asset, transactions of type ASSET_DIVIDEND are not considered. That makes the return rate computed by beangrow substantially different to rates reported by fund managers.

I could not find any justification as to why these transactions are ignored when computing the return rates, and this seems to confuse me as well as other users. See beancount/beangrow#23 and beancount/beangrow#26

At least with this small patch, users get a chance to try and see if they get the result they expected.