### PR TITLE
use https protocol to install beanprice

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -75,7 +75,7 @@ requests = "*"
 
 [package.source]
 type = "git"
-url = "git@github.com:beancount/beanprice.git"
+url = "git+https://github.com/beancount/beanprice.git"
 reference = "HEAD"
 resolved_reference = "41576e2ac889e4825e4985b6f6c56aa71de28304"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pandas = "^2.2.2"
 matplotlib = "^3.9.0"
 beancount = "^2.3.6"
 scipy = "^1.13.1"
-beanprice = {git = "git@github.com:beancount/beanprice.git"}
+beanprice = {git = "git+https://github.com/beancount/beanprice.git"}
 pandas-stubs = "^2.2.2.240514"
 matplotlib-stubs = "^0.2.0"
 
@@ -127,4 +127,3 @@ python_files = "*.py"
 testpaths = [
     "tests",
 ]
-


### PR DESCRIPTION
Using the SSH protocol in poetry to download dependencies affects the installation on GitHub Action.

While this should be possible with clever solutions such as setting up the SSH Key Agent, it is far less straightforward than using the HTTPS protocol directly.

This change replaces the SSH protocol in the dependency file with the HTTPS protocol.