### PR TITLE
compute_returns_beam.py: Do not hardcode python3.8 shebang

### DIFF
--- a/beangrow/compute_returns_beam.py
+++ b/beangrow/compute_returns_beam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 """Calculate my true returns, including dividends and real costs.
 """
 


### PR DESCRIPTION
Use "python3" instead of "python3.8".