### PR TITLE
move type definition dependencies to dev dependencies group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,17 @@ dependencies = [
     'beancount >= 2.3.6',
     'scipy >= 1.13.1',
     'beanprice >= 1.2.1',
+    'protobuf >= 5.29.3',
+]
+
+[dependency-groups]
+dev = [
+    'ruff >= 0.9.3',
     'pandas-stubs >= 2.2.2.240514',
     'matplotlib-stubs >= 0.2.0',
-    "protobuf >= 5.29.3",
+    'mypy>=1.14.1',
+    'types-protobuf>=5.29.1.20241207',
+    'types-python-dateutil>=2.9.0.20241206',
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Move type definition dependencies to dev dependencies group.

I also added `ruff` and `mypy`, but didn't run the formatter yet - it would reformat pretty much all files. I'll leave it up to you if you want to apply the formatting by ruff or not (maybe we should also sync the ruff settings across the beancount projects?).

see https://github.com/beancount/beangrow/pull/38#discussion_r1929854866