### PR TITLE
Fix final price when truncating cash flows

### DIFF
--- a/beangrow/config.py
+++ b/beangrow/config.py
@@ -32,16 +32,15 @@ def expand_globs(patterns: List[str], valid_set: List[str]) -> List[str]:
     return out_values
 
 
-def read_config(config_filename: str,
+def read_config_from_string(config_string: str,
                 filter_reports: List[str],
                 accounts: List[Account]) -> Config:
     """Read the configuration, perform globbing expansions, and whittle down the
     list of reports and investments to the requested minimal."""
 
-    # Read the file.
+    # Read the config from a string.
     config = Config()
-    with open(config_filename, "r") as infile:
-        text_format.Merge(infile.read(), config)
+    text_format.Merge(config_string, config)
     reports = list(config.groups.group)
 
     # Expand account names.
@@ -78,3 +77,13 @@ def read_config(config_filename: str,
     config.investments.investment.extend(investments)
 
     return config
+
+
+def read_config(config_filename: str,
+                filter_reports: List[str],
+                accounts: List[Account]) -> Config:
+    # Read the file.
+    with open(config_filename, "r") as infile:
+        config_string = infile.read()
+
+    return read_config_from_string(config_string, filter_reports, accounts)

--- a/beangrow/investments.py
+++ b/beangrow/investments.py
@@ -433,7 +433,7 @@ def prune_entries(entries: data.Entries, config: Config) -> data.Entries:
 
 def compute_balance_at(transactions: data.Entries,
                        date: Optional[Date] = None) -> Inventory:
-    """Compute the balance at a specific date."""
+    """Compute the balance before a specific date."""
     balance = Inventory()
     for entry in transactions:
         if date is not None and entry.date >= date:

--- a/beangrow/returns.py
+++ b/beangrow/returns.py
@@ -27,6 +27,7 @@ Currency = str
 Date = datetime.date
 Array = np.ndarray
 
+ONE_DAY = datetime.timedelta(days=1)
 
 class Pricer:
     """A price database that remembers the queried prices and dates."""
@@ -295,7 +296,7 @@ def truncate_cash_flows( # noqa: C901
         # caching it on every single transaction.
         balance = compute_balance_at(account_data.transactions, date_end)
         if not balance.is_empty():
-            cost_balance = balance.reduce(pricer.get_value, date_end)
+            cost_balance = balance.reduce(pricer.get_value, date_end - ONE_DAY)
             cost_position = cost_balance.get_only_position()
             if cost_position:
                 end_flows.append(

--- a/beangrow/returns_test.py
+++ b/beangrow/returns_test.py
@@ -1,0 +1,126 @@
+import datetime
+import unittest
+from decimal import Decimal as D
+from beancount import loader
+from beancount.core.amount import Amount
+from beancount.core import getters
+from beancount.core import prices
+from pytest import approx
+from beangrow.config import read_config_from_string
+from beangrow.investments import extract, CashFlow
+from beangrow.returns import Pricer, compute_irr, truncate_cash_flows
+
+
+def load(ledger: str, beangrow_cfg: str):
+    entries, errors, options_map = loader.load_string(ledger)
+    if errors:
+        raise ValueError(errors)
+
+    dcontext = options_map["dcontext"]
+    accounts = getters.get_accounts(entries)
+    price_map = prices.build_price_map(entries)
+    pricer = Pricer(price_map)
+    beangrow_config = read_config_from_string(beangrow_cfg, [], list(accounts))
+    account_data_map = extract(entries, dcontext, beangrow_config, entries[-1].date, False, "")
+
+    return pricer, account_data_map
+
+
+TEST_CONFIG = """
+investments {
+  investment {
+    currency: "CORP"
+    asset_account: "Assets:CORP"
+    dividend_accounts: "Income:CORP:Dividend"
+    cash_accounts: "Assets:Cash"
+  }
+}
+groups {
+  group {
+    name: "CORP"
+    investment: "Assets:CORP"
+  }
+}
+"""
+
+TEST_LEDGER = """
+plugin "beancount.plugins.auto_accounts"
+plugin "beancount.plugins.implicit_prices"
+
+2020-01-01 commodity CORP
+
+2020-12-28 * "Buy 1 CORP"
+  Assets:CORP                                           1 CORP {101 USD}
+  Assets:Cash
+
+2020-12-29 * "Buy 1 CORP"
+  Assets:CORP                                           1 CORP {102 USD}
+  Assets:Cash
+
+2020-12-30 * "Buy 1 CORP"
+  Assets:CORP                                           1 CORP {103 USD}
+  Assets:Cash
+
+2020-12-31 * "Buy 1 CORP"
+  Assets:CORP                                           1 CORP {104 USD}
+  Assets:Cash
+
+2021-01-01 * "Buy 1 CORP"
+  Assets:CORP                                           1 CORP {105 USD}
+  Assets:Cash
+"""
+
+
+class ReturnsTest(unittest.TestCase):
+    def test_truncate_cash_flows(self):
+        pricer, account_data_map = load(TEST_LEDGER, TEST_CONFIG)
+
+        cash_flows = truncate_cash_flows(
+            pricer, account_data_map["Assets:CORP"], datetime.date(2020, 12, 30), datetime.date(2021, 1, 1)
+        )
+        assert cash_flows == [
+            # truncate flows before 2020-12-30
+            # balance before 2020-12-30: 2 CORP
+            # price on 2020-12-30: 103 USD
+            CashFlow(
+                date=datetime.date(2020, 12, 30),
+                amount=Amount(D(-2 * 103), "USD"),
+                is_dividend=False,
+                source="open",
+                account="Assets:CORP",
+            ),
+            CashFlow(
+                date=datetime.date(2020, 12, 30),
+                amount=Amount(D(-103), "USD"),
+                is_dividend=False,
+                source="cash",
+                account="Assets:CORP",
+            ),
+            CashFlow(
+                date=datetime.date(2020, 12, 31),
+                amount=Amount(D(-104), "USD"),
+                is_dividend=False,
+                source="cash",
+                account="Assets:CORP",
+            ),
+            # balance before 2021-01-01: 4 CORP
+            # price on 2020-12-31: 104 USD
+            CashFlow(
+                date=datetime.date(2021, 1, 1),
+                amount=Amount(D(4 * 104), "USD"),
+                is_dividend=False,
+                source="close",
+                account="Assets:CORP",
+            ),
+        ]
+
+    def test_compute_irr(self):
+        pricer, account_data_map = load(TEST_LEDGER, TEST_CONFIG)
+        cash_flows = truncate_cash_flows(
+            pricer, account_data_map["Assets:CORP"], datetime.date(2020, 12, 30), datetime.date(2021, 1, 1)
+        )
+
+        # 206 USD invested for 2 days + 103 USD invested for 2 days + 104 USD invested for 1 day = 416 USD
+        # 206*(1+x)^(2/365) + 103*(1+x)^(2/365) + 104*(1+x)^(1/365) = 416
+        irr = compute_irr(cash_flows, pricer, "USD", datetime.date(2021, 1, 1))
+        assert irr == approx(3.530, abs=0.001)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     'mypy>=1.14.1',
     'types-protobuf>=5.29.1.20241207',
     'types-python-dateutil>=2.9.0.20241206',
+    "pytest>=8.3.4",
 ]
 
 [tool.setuptools]
@@ -135,15 +136,3 @@ ignore = [
 [tool.coverage.report]
 skip_covered = true
 skip_empty = true
-
-[tool.pytest.ini_options]
-# Use recommended import mode
-addopts = [
-    "--import-mode=importlib",
-]
-
-# Make it so you don't have to prefix every file with `test_`
-python_files = "*.py"
-testpaths = [
-    "tests",
-]


### PR DESCRIPTION
I believe there is a off-by-one error on the final truncated cash flow:

When cash flows are truncated between [2020-12-30, 2021-01-01[, the balance before 2021-01-01 should be evaluated at the price of 2020-12-31, not 2021-01-01.

I added a unit test for this and for the IRR calculation.