### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "beangrow"
-version = '1.0.1'
+version = '1.1.0'
 description = 'Returns calculations on portfolios in Beancount Resources'
 authors = [
     { name = 'Martin Blais', email = 'blais@furius.ca' },


### PR DESCRIPTION
There were a few interesting changes since 1.0.1 ([diff](https://github.com/beancount/beangrow/compare/7204423e7933fe62d612ef63093300c614519d29...master)), it'd be great to cut a new release.